### PR TITLE
feat(account): Cloudflare Access によるユーザー識別とアバター表示を追加

### DIFF
--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -384,6 +384,19 @@ document.addEventListener('change', e => {
   applyFilters();
 });
 
+async function initUserUI() {
+  try {
+    const res = await fetch('/api/me');
+    if (!res.ok) return;
+    const { email, initial } = await res.json();
+    const el = document.getElementById('userAvatar');
+    if (!el) return;
+    el.textContent = initial; // textContent のみ（XSS防止）
+    el.title = email;
+    el.style.display = '';
+  } catch { /* オフライン・Access未設定時は表示しない */ }
+}
+
 function initMemoUI() {
   document.querySelectorAll('.memo-input').forEach(textarea => {
     const id = textarea.dataset.eventId;
@@ -402,7 +415,7 @@ function initMemoUI() {
 (async () => {
   // 初期化完了まで操作を無効化（APIフェッチ中の競合防止）
   document.querySelectorAll('.viewing-select').forEach(sel => { sel.disabled = true; });
-  await ViewingStorage.init();
+  await Promise.all([ViewingStorage.init(), initUserUI()]);
   initStatusUI();
   initMemoUI();
   document.querySelectorAll('.viewing-select').forEach(sel => { sel.disabled = false; });

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -3,6 +3,13 @@ body { font-family: 'Hiragino Sans', 'Noto Sans JP', sans-serif; background: #f0
 header { background: #1a1a2e; color: #fff; padding: 16px 20px; }
 header h1 { font-size: 18px; font-weight: bold; }
 header p { font-size: 12px; color: #aaa; margin-top: 4px; }
+.header-inner { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.user-avatar {
+  width: 34px; height: 34px; border-radius: 50%;
+  background: #3d3d5c; color: #fff;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; font-weight: bold; flex-shrink: 0; cursor: default;
+}
 .container { max-width: 900px; margin: 0 auto; padding: 16px; }
 
 /* タブ */

--- a/functions/api/me.js
+++ b/functions/api/me.js
@@ -1,0 +1,18 @@
+/**
+ * GET /api/me — 認証済みユーザーの情報を返す
+ * Cloudflare Access が付与する CF-Access-Authenticated-User-Email ヘッダーを使用する。
+ */
+
+export async function onRequestGet({ request }) {
+  const email = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  if (!email) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return new Response(
+    JSON.stringify({ email, initial: email[0].toUpperCase() }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}

--- a/functions/api/viewing-statuses/[eventId].js
+++ b/functions/api/viewing-statuses/[eventId].js
@@ -1,12 +1,13 @@
 /**
- * PATCH /api/viewing-statuses/:eventId  — 単一イベントの観覧ステータスを更新
+ * PATCH /api/viewing-statuses/:eventId  — 単一イベントの観覧ステータス・メモを更新
  * DELETE /api/viewing-statuses/:eventId — 単一イベントの観覧ステータスを削除
+ *
+ * ユーザー識別: Cloudflare Access が付与する CF-Access-Authenticated-User-Email を使用。
+ * KVキー: `status:{sha256(email)}`（メールアドレスを平文でKVに保存しない）
  */
 
-const KV_KEY = 'user_viewing_statuses';
 const EMPTY_DATA = { schema_version: 1, statuses: {} };
 
-// フロントエンドの VIEWING_STATUSES と同期させること
 const VALID_VIEWING_STATUSES = new Set([
   'want',
   'lottery_applied',
@@ -19,14 +20,22 @@ const EVENT_ID_RE = /^[0-9a-f]{8}$/;
 const MEMO_MAX_LEN = 1000;
 const HISTORY_MAX_LEN = 100;
 
-async function loadData(env) {
-  const data = await env.FANABY_VIEWING_STATUSES.get(KV_KEY, 'json');
+async function getUserKey(request) {
+  const email = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  if (!email) return null;
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(email));
+  const hex = Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `status:${hex}`;
+}
+
+async function loadData(env, kvKey) {
+  const data = await env.FANABY_VIEWING_STATUSES.get(kvKey, 'json');
   return data || { ...EMPTY_DATA, statuses: {} };
 }
 
-async function saveData(env, data) {
+async function saveData(env, kvKey, data) {
   data.updated_at = new Date().toISOString();
-  await env.FANABY_VIEWING_STATUSES.put(KV_KEY, JSON.stringify(data));
+  await env.FANABY_VIEWING_STATUSES.put(kvKey, JSON.stringify(data));
 }
 
 function jsonResponse(body, status = 200) {
@@ -36,54 +45,55 @@ function jsonResponse(body, status = 200) {
   });
 }
 
-export async function onRequestPatch(context) {
-  const eventId = context.params.eventId;
+export async function onRequestPatch({ request, params, env }) {
+  const kvKey = await getUserKey(request);
+  if (!kvKey) return jsonResponse({ error: 'Unauthorized' }, 401);
 
-  if (!EVENT_ID_RE.test(eventId)) {
-    return jsonResponse({ error: 'invalid eventId' }, 400);
-  }
+  const eventId = params.eventId;
+  if (!EVENT_ID_RE.test(eventId)) return jsonResponse({ error: 'invalid eventId' }, 400);
 
   let body;
   try {
-    body = await context.request.json();
+    body = await request.json();
   } catch {
     return jsonResponse({ error: 'invalid JSON' }, 400);
   }
 
-  if (!body || !body.status) {
-    return jsonResponse({ error: 'status required' }, 400);
+  if (!body) return jsonResponse({ error: 'request body required' }, 400);
+
+  // status と memo の両方が未指定はエラー
+  if (body.status === undefined && body.memo === undefined) {
+    return jsonResponse({ error: 'status or memo required' }, 400);
   }
-  if (!VALID_VIEWING_STATUSES.has(body.status)) {
+  // status が指定されている場合はホワイトリスト検証（空文字はステータスなしとして許容）
+  if (body.status !== undefined && body.status !== '' && !VALID_VIEWING_STATUSES.has(body.status)) {
     return jsonResponse({ error: 'invalid status value' }, 400);
   }
   if (body.memo !== undefined) {
-    if (typeof body.memo !== 'string') {
-      return jsonResponse({ error: 'memo must be a string' }, 400);
-    }
-    if (body.memo.length > MEMO_MAX_LEN) {
-      return jsonResponse({ error: `memo exceeds ${MEMO_MAX_LEN} chars` }, 400);
-    }
+    if (typeof body.memo !== 'string') return jsonResponse({ error: 'memo must be a string' }, 400);
+    if (body.memo.length > MEMO_MAX_LEN) return jsonResponse({ error: `memo exceeds ${MEMO_MAX_LEN} chars` }, 400);
   }
 
   try {
-    const data = await loadData(context.env);
+    const data = await loadData(env, kvKey);
     const now = new Date().toISOString();
-    const existing = data.statuses[eventId] || { history: [], memo: '' };
+    const existing = data.statuses[eventId] || { history: [], memo: '', status: '' };
 
-    existing.status = body.status;
-    existing.updated_at = now;
-    existing.history = existing.history || [];
-    existing.history.push({ status: body.status, at: now });
-
-    // 履歴が上限を超えたら古いものを削除
-    if (existing.history.length > HISTORY_MAX_LEN) {
-      existing.history = existing.history.slice(-HISTORY_MAX_LEN);
+    if (body.status !== undefined) {
+      existing.status = body.status;
+      if (body.status) {
+        existing.history = existing.history || [];
+        existing.history.push({ status: body.status, at: now });
+        if (existing.history.length > HISTORY_MAX_LEN) {
+          existing.history = existing.history.slice(-HISTORY_MAX_LEN);
+        }
+      }
     }
-
     if (body.memo !== undefined) existing.memo = body.memo;
+    existing.updated_at = now;
 
     data.statuses[eventId] = existing;
-    await saveData(context.env, data);
+    await saveData(env, kvKey, data);
 
     return jsonResponse({ ok: true, updated_at: now });
   } catch (e) {
@@ -92,18 +102,17 @@ export async function onRequestPatch(context) {
   }
 }
 
-export async function onRequestDelete(context) {
-  const eventId = context.params.eventId;
+export async function onRequestDelete({ request, params, env }) {
+  const kvKey = await getUserKey(request);
+  if (!kvKey) return jsonResponse({ error: 'Unauthorized' }, 401);
 
-  if (!EVENT_ID_RE.test(eventId)) {
-    return jsonResponse({ error: 'invalid eventId' }, 400);
-  }
+  const eventId = params.eventId;
+  if (!EVENT_ID_RE.test(eventId)) return jsonResponse({ error: 'invalid eventId' }, 400);
 
   try {
-    const data = await loadData(context.env);
+    const data = await loadData(env, kvKey);
     delete data.statuses[eventId];
-    await saveData(context.env, data);
-
+    await saveData(env, kvKey, data);
     return jsonResponse({ ok: true });
   } catch (e) {
     console.error('DELETE /api/viewing-statuses/:eventId error:', e);

--- a/functions/api/viewing-statuses/index.js
+++ b/functions/api/viewing-statuses/index.js
@@ -1,13 +1,21 @@
 /**
- * GET /api/viewing-statuses  — 全観覧ステータスを取得
+ * GET /api/viewing-statuses  — ユーザーの全観覧ステータスを取得
  * PUT /api/viewing-statuses  — 全ステータスを一括置換（移行・インポート用）
+ *
+ * ユーザー識別: Cloudflare Access が付与する CF-Access-Authenticated-User-Email を使用。
+ * KVキー: `status:{sha256(email)}`（メールアドレスを平文でKVに保存しない）
  */
 
-const KV_KEY = 'user_viewing_statuses';
 const EMPTY_DATA = { schema_version: 1, statuses: {} };
+const PUT_SIZE_LIMIT = 1024 * 1024; // 1MB
 
-// PUT ペイロードの上限（25MiB のうち安全マージン: 1MB）
-const PUT_SIZE_LIMIT = 1024 * 1024;
+async function getUserKey(request) {
+  const email = request.headers.get('CF-Access-Authenticated-User-Email') || '';
+  if (!email) return null;
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(email));
+  const hex = Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `status:${hex}`;
+}
 
 function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -16,9 +24,12 @@ function jsonResponse(body, status = 200) {
   });
 }
 
-export async function onRequestGet(context) {
+export async function onRequestGet({ request, env }) {
+  const kvKey = await getUserKey(request);
+  if (!kvKey) return jsonResponse({ error: 'Unauthorized' }, 401);
+
   try {
-    const data = await context.env.FANABY_VIEWING_STATUSES.get(KV_KEY, 'json');
+    const data = await env.FANABY_VIEWING_STATUSES.get(kvKey, 'json');
     return jsonResponse(data || EMPTY_DATA);
   } catch (e) {
     console.error('GET /api/viewing-statuses error:', e);
@@ -26,27 +37,21 @@ export async function onRequestGet(context) {
   }
 }
 
-export async function onRequestPut(context) {
-  // ペイロードサイズチェック
-  const contentLength = parseInt(context.request.headers.get('content-length') || '0', 10);
-  if (contentLength > PUT_SIZE_LIMIT) {
-    return jsonResponse({ error: 'payload too large' }, 413);
-  }
+export async function onRequestPut({ request, env }) {
+  const kvKey = await getUserKey(request);
+  if (!kvKey) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  const contentLength = parseInt(request.headers.get('content-length') || '0', 10);
+  if (contentLength > PUT_SIZE_LIMIT) return jsonResponse({ error: 'payload too large' }, 413);
 
   let body;
   try {
-    body = await context.request.json();
+    body = await request.json();
   } catch {
     return jsonResponse({ error: 'invalid JSON' }, 400);
   }
 
-  // statuses が null や配列でないことも確認
-  if (
-    !body ||
-    body.statuses === null ||
-    Array.isArray(body.statuses) ||
-    typeof body.statuses !== 'object'
-  ) {
+  if (!body || body.statuses === null || Array.isArray(body.statuses) || typeof body.statuses !== 'object') {
     return jsonResponse({ error: 'invalid schema' }, 400);
   }
 
@@ -54,7 +59,7 @@ export async function onRequestPut(context) {
   body.updated_at = new Date().toISOString();
 
   try {
-    await context.env.FANABY_VIEWING_STATUSES.put(KV_KEY, JSON.stringify(body));
+    await env.FANABY_VIEWING_STATUSES.put(kvKey, JSON.stringify(body));
     return jsonResponse({ ok: true });
   } catch (e) {
     console.error('PUT /api/viewing-statuses error:', e);

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -223,8 +223,13 @@ def main():
 </head>
 <body>
   <header>
-    <h1>公演スケジュール</h1>
-    <p>最終更新: {escape_html(updated_str)}</p>
+    <div class="header-inner">
+      <div>
+        <h1>公演スケジュール</h1>
+        <p>最終更新: {escape_html(updated_str)}</p>
+      </div>
+      <div id="userAvatar" class="user-avatar" style="display:none" title=""></div>
+    </div>
   </header>
   <div class="container">
     <div class="tabs">


### PR DESCRIPTION
- functions/api/me.js: GET /api/me エンドポイントを新規追加
- functions/api/viewing-statuses/index.js: KVキーをユーザーごとに分離 CF-Access-Authenticated-User-Email の SHA-256 ハッシュをKVキーに使用
- functions/api/viewing-statuses/[eventId].js: 同上 + メモのみ更新を許可 status 必須制約を緩和し status/memo いずれか一方でも更新可能に
- build.py: ヘッダーにユーザーアバター要素を追加
- script.js: initUserUI() を追加し /api/me からユーザー情報を取得・表示
- style.css: .header-inner / .user-avatar のスタイルを追加